### PR TITLE
Exclude some dirs from syncing and cleaning

### DIFF
--- a/jsc/container.py
+++ b/jsc/container.py
@@ -416,7 +416,7 @@ def clean(datasets):
             pacman_db_dir = os.path.join(STATE_DIR, ".pacman", "db")
             subprocess.check_call("rm -rf {pacman_db_dir}".format(pacman_db_dir=pacman_db_dir), shell=True)
             for node in os.listdir(CODE_DIR):
-                if node not in ("lost+found", ".jsc", ".pacman"):
+                if node not in ("lost+found", ".jsc", ".pacman", ".config"):
                     node_path = os.path.join(CODE_DIR, node)
                     subprocess.check_call("rm -rf {node_path}".format(node_path=node_path), shell=True)
             log("{dataset} was cleaned".format(dataset=dataset))

--- a/jsc/main.py
+++ b/jsc/main.py
@@ -66,6 +66,12 @@ def rsync(conn, src, dst):
     class JSRSync(execnet.RSync):
         def _report_send_file(self, gateway, modified_rel_path):
             log.info("syncing file: %s" % modified_rel_path)
+        def filter(self, path):
+            excluded_dirs = ['.svn', '.git']
+            last_part = path.split(os.sep).pop()
+            if last_part in excluded_dirs:
+                return False
+            return True
     sync = JSRSync(src)
     sync.add_target(conn.gateway, dst)
     sync.send()


### PR DESCRIPTION
It's not necessary to sync hidden VCS dirs such as .svn and .git to remote server. For example while syncing recipe (`deploy` command) from local directory which is svn checkout.

Do not wipe out .config dir in /app/code with `clean` command. It can contains useful configurations, such as fish shell aliases, etc...
